### PR TITLE
feat: add email queueing and user email verification middleware

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Notifications\Auth\QueuedResetPassword;
+use App\Notifications\Auth\QueuedVerifyEmail;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 
 use Egulias\EmailValidator\Parser\Comment;
@@ -79,11 +81,17 @@ class User extends Authenticatable implements MustVerifyEmail
 
     public function sendPasswordResetNotification($token): void
     {
-        $this->notify(new ResetPasswordNotification($token));
+        $this->notify(new QueuedResetPassword($token));
     }
 
     public function savedPosts()
     {
         return $this->belongsToMany(Post::class, 'saved_posts');
+    }
+
+    //Overrideen sendEmailVerificationNotification implementation
+    public function sendEmailVerificationNotification()
+    {
+        $this->notify(new QueuedVerifyEmail);
     }
 }

--- a/app/Notifications/Auth/QueuedResetPassword.php
+++ b/app/Notifications/Auth/QueuedResetPassword.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Notifications\Auth;
+
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class QueuedResetPassword extends ResetPassword implements ShouldQueue
+{
+    use Queueable;
+}

--- a/app/Notifications/Auth/QueuedVerifyEmail.php
+++ b/app/Notifications/Auth/QueuedVerifyEmail.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Notifications\Auth;
+
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class QueuedVerifyEmail extends VerifyEmail implements ShouldQueue
+{
+    use Queueable;
+}

--- a/database/migrations/2024_04_11_090348_create_jobs_table.php
+++ b/database/migrations/2024_04_11_090348_create_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Route;
 //     return view('dashboard');
 // })->middleware(['auth', 'verified'])->name('dashboard');
 
-Route::middleware('auth')->group(function () {
+Route::middleware('auth', 'verified')->group(function () {
 
     Route::get('/', HomeController::class)->name('home');
     // Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
# Changes
- [x] Make sure any sending emails is using Laravel queues
- [x] prevent users from logging in without verifying their email

# IMPORTANT NOTES
- To make Laravel queues work, you should first edit the value of `QUEUE_CONNECTION` in the `.env` file from `sync` to `database`, so it will look like `QUEUE_CONNECTION=database` in the end.